### PR TITLE
 fix usage of TileGrid

### DIFF
--- a/adafruit_slideshow.py
+++ b/adafruit_slideshow.py
@@ -313,7 +313,10 @@ class SlideShow:
         if not odb:
             raise RuntimeError("No valid images")
 
-        sprite = self._sprite_class(odb, pixel_shader=displayio.ColorConverter(), position=(0, 0))
+        try:
+            sprite = self._sprite_class(odb, pixel_shader=displayio.ColorConverter())
+        except TypeError:
+            sprite = self._sprite_class(odb, pixel_shader=displayio.ColorConverter(), position=(0, 0))
         self._group.append(sprite)
         self._display.wait_for_frame()
 

--- a/adafruit_slideshow.py
+++ b/adafruit_slideshow.py
@@ -314,9 +314,11 @@ class SlideShow:
             raise RuntimeError("No valid images")
 
         try:
-            sprite = self._sprite_class(odb, pixel_shader=displayio.ColorConverter())
+            sprite = self._sprite_class(odb,
+                                        pixel_shader=displayio.ColorConverter())
         except TypeError:
-            sprite = self._sprite_class(odb, pixel_shader=displayio.ColorConverter(), position=(0, 0))
+            sprite = self._sprite_class(odb,
+                                        pixel_shader=displayio.ColorConverter(), position=(0, 0))
         self._group.append(sprite)
         self._display.wait_for_frame()
 


### PR DESCRIPTION
TileGrid in displayio no longer accepts kwarg position - uses x,y.
In this case - just omit since default is 0,0
modify with try/except for "backward compatibility)