### PR TITLE
remove unnecessary wait_for_frame call for CP5.0 compatibility

### DIFF
--- a/adafruit_slideshow.py
+++ b/adafruit_slideshow.py
@@ -320,12 +320,6 @@ class SlideShow:
             sprite = self._sprite_class(odb,
                                         pixel_shader=displayio.ColorConverter(), position=(0, 0))
         self._group.append(sprite)
-        # wait_for_frame is no longer needed in CP5.0
-        # use try/except for backward compatibility
-        try:
-            self._display.wait_for_frame()
-        except AttributeError:
-            pass
 
         self._fade_up()
         self._img_start = time.monotonic()

--- a/adafruit_slideshow.py
+++ b/adafruit_slideshow.py
@@ -320,7 +320,12 @@ class SlideShow:
             sprite = self._sprite_class(odb,
                                         pixel_shader=displayio.ColorConverter(), position=(0, 0))
         self._group.append(sprite)
-        self._display.wait_for_frame()
+        # wait_for_frame is no longer needed in CP5.0
+        # use try/except for backward compatibility
+        try:
+            self._display.wait_for_frame()
+        except AttributeError:
+            pass
 
         self._fade_up()
         self._img_start = time.monotonic()


### PR DESCRIPTION
displayio no longer supports "wait_for_frame()"  uses display.auto_refresh which is enabled by default.
use try/except for backward compatibility.

tested on feather_m4_express with TFT featherwing and on PyPortal