### PR TITLE
Allow text slides

### DIFF
--- a/adafruit_slideshow.py
+++ b/adafruit_slideshow.py
@@ -43,11 +43,14 @@ Implementation Notes
 import time
 import os
 import random
-import displayio
 import json
+import displayio
+
+
 try:
     from adafruit_display_text import bitmap_label
     import terminalio
+
     TEXT_SLIDES_ENABLED = True
 except ImportError:
     TEXT_SLIDES_ENABLED = False
@@ -199,14 +202,15 @@ class SlideShow:
     ):
         def _check_json_file(file):
             if TEXT_SLIDES_ENABLED:
-                with open(file) as f:
+                with open(file) as _file_obj:
                     try:
-                        json_data = json.loads(f.read())
+                        json_data = json.loads(_file_obj.read())
                         if "text" in json_data:
                             return True
                     except ValueError:
                         return False
             return False
+
         self.loop = loop
         """Specifies whether to loop through the slides continuously or play through the list once.
         ``True`` will continue to loop, ``False`` will play only once."""
@@ -231,7 +235,10 @@ class SlideShow:
         self._file_list = [
             folder + "/" + f
             for f in os.listdir(folder)
-            if ((f.endswith(".bmp") or _check_json_file(folder + "/" + f)) and not f.startswith("."))
+            if (
+                (f.endswith(".bmp") or _check_json_file(folder + "/" + f))
+                and not f.startswith(".")
+            )
         ]
 
         self._order = None
@@ -336,7 +343,9 @@ class SlideShow:
         if "scale" in json_data:
             _scale = int(json_data["scale"])
 
-        label = bitmap_label.Label(terminalio.FONT, text=json_data['text'], scale=_scale)
+        label = bitmap_label.Label(
+            terminalio.FONT, text=json_data["text"], scale=_scale
+        )
         if "h_align" not in json_data or json_data["h_align"] == "LEFT":
             x_anchor_point = 0.0
             x_anchored_position = 0
@@ -375,7 +384,6 @@ class SlideShow:
         label.anchored_position = (x_anchored_position, y_anchored_position)
         return label
 
-
     def update(self):
         """Updates the slideshow to the next image."""
         now = time.monotonic()
@@ -383,7 +391,7 @@ class SlideShow:
             return True
         return self.advance()
 
-    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-branches, too-many-statements
     def advance(self):
         """Displays the next image. Returns True when a new image was displayed, False otherwise."""
         if self._slide_file:
@@ -441,7 +449,9 @@ class SlideShow:
             else:
                 self._group.y = 0
 
-            image_tilegrid = displayio.TileGrid(odb, pixel_shader=displayio.ColorConverter())
+            image_tilegrid = displayio.TileGrid(
+                odb, pixel_shader=displayio.ColorConverter()
+            )
 
             self._group.append(image_tilegrid)
         if lbl:

--- a/adafruit_slideshow.py
+++ b/adafruit_slideshow.py
@@ -44,6 +44,7 @@ import time
 import os
 import random
 import displayio
+import json
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Slideshow.git"
@@ -190,6 +191,15 @@ class SlideShow:
         h_align=HorizontalAlignment.LEFT,
         v_align=VerticalAlignment.TOP,
     ):
+        def _check_json_file(file):
+            with open(file) as f:
+                try:
+                    json_data = json.loads(f.read())
+                    if "text" in json_data:
+                        return True
+                except ValueError:
+                    return False
+            return False
         self.loop = loop
         """Specifies whether to loop through the images continuously or play through the list once.
         ``True`` will continue to loop, ``False`` will play only once."""
@@ -214,7 +224,7 @@ class SlideShow:
         self._file_list = [
             folder + "/" + f
             for f in os.listdir(folder)
-            if (f.endswith(".bmp") and not f.startswith("."))
+            if ((f.endswith(".bmp") or _check_json_file(folder + "/" + f)) and not f.startswith("."))
         ]
 
         self._order = None

--- a/adafruit_slideshow.py
+++ b/adafruit_slideshow.py
@@ -332,7 +332,11 @@ class SlideShow:
 
     def _create_label(self, file):
         json_data = json.loads(file.read())
-        label = bitmap_label.Label(terminalio.FONT, text=json_data['text'])
+        _scale = 1
+        if "scale" in json_data:
+            _scale = int(json_data["scale"])
+
+        label = bitmap_label.Label(terminalio.FONT, text=json_data['text'], scale=_scale)
         if "h_align" not in json_data or json_data["h_align"] == "LEFT":
             x_anchor_point = 0.0
             x_anchored_position = 0
@@ -360,6 +364,12 @@ class SlideShow:
             # wrong value for align
             y_anchor_point = 0.0
             y_anchored_position = 0
+
+        if "background_color" in json_data:
+            label.background_color = int(json_data["background_color"], 16)
+
+        if "color" in json_data:
+            label.color = int(json_data["color"], 16)
 
         label.anchor_point = (x_anchor_point, y_anchor_point)
         label.anchored_position = (x_anchored_position, y_anchored_position)

--- a/adafruit_slideshow.py
+++ b/adafruit_slideshow.py
@@ -47,11 +47,14 @@ import json
 import displayio
 
 try:
+    # text slides are an optional feature and require
+    # adafruit_display_text
     from adafruit_display_text import bitmap_label
     import terminalio
 
     TEXT_SLIDES_ENABLED = True
 except ImportError:
+    print("Warning: adafruit_display_text not found. No support for text slides.")
     TEXT_SLIDES_ENABLED = False
 
 __version__ = "0.0.0-auto.0"

--- a/adafruit_slideshow.py
+++ b/adafruit_slideshow.py
@@ -47,8 +47,7 @@ import json
 import displayio
 
 try:
-    # text slides are an optional feature and require
-    # adafruit_display_text
+    # text slides are an optional feature and require adafruit_display_text
     from adafruit_display_text import bitmap_label
     import terminalio
 
@@ -56,6 +55,15 @@ try:
 except ImportError:
     print("Warning: adafruit_display_text not found. No support for text slides.")
     TEXT_SLIDES_ENABLED = False
+
+try:
+    # custom fonts are an optional feature and require adafruit_bitmap_font
+    from adafruit_bitmap_font import bitmap_font
+
+    CUSTOM_FONTS = True
+except ImportError:
+    print("Warning: adafruit_bitmap_font not found. No support for custom fonts.")
+    CUSTOM_FONTS = False
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Slideshow.git"
@@ -341,6 +349,7 @@ class SlideShow:
             time.sleep(0.01)
 
     def _create_label(self, file):
+        # pylint: disable=too-many-branches
         """Creates and returns a label from a file object that contains
         valid valid json describing the text to use.
         See: examples/sample_text_slide.json
@@ -350,9 +359,15 @@ class SlideShow:
         if "scale" in json_data:
             _scale = int(json_data["scale"])
 
-        label = bitmap_label.Label(
-            terminalio.FONT, text=json_data["text"], scale=_scale
-        )
+        if CUSTOM_FONTS:
+            if "font" in json_data:
+                _font = bitmap_font.load_font(json_data["font"])
+            else:
+                _font = terminalio.FONT
+        else:
+            _font = terminalio.FONT
+
+        label = bitmap_label.Label(_font, text=json_data["text"], scale=_scale)
         if "h_align" not in json_data or json_data["h_align"] == "LEFT":
             x_anchor_point = 0.0
             x_anchored_position = 0

--- a/adafruit_slideshow.py
+++ b/adafruit_slideshow.py
@@ -46,7 +46,6 @@ import random
 import json
 import displayio
 
-
 try:
     from adafruit_display_text import bitmap_label
     import terminalio
@@ -202,13 +201,14 @@ class SlideShow:
     ):
         def _check_json_file(file):
             if TEXT_SLIDES_ENABLED:
-                with open(file) as _file_obj:
-                    try:
-                        json_data = json.loads(_file_obj.read())
-                        if "text" in json_data:
-                            return True
-                    except ValueError:
-                        return False
+                if file.endswith(".json"):
+                    with open(file) as _file_obj:
+                        try:
+                            json_data = json.loads(_file_obj.read())
+                            if "text" in json_data:
+                                return True
+                        except ValueError:
+                            return False
             return False
 
         self.loop = loop
@@ -233,11 +233,11 @@ class SlideShow:
         # Load the image names before setting order so they can be reordered.
         self._img_start = None
         self._file_list = [
-            folder + "/" + f
+            folder + f
             for f in os.listdir(folder)
             if (
-                (f.endswith(".bmp") or _check_json_file(folder + "/" + f))
-                and not f.startswith(".")
+                not f.startswith(".")
+                and (f.endswith(".bmp") or _check_json_file(folder + f))
             )
         ]
 

--- a/adafruit_slideshow.py
+++ b/adafruit_slideshow.py
@@ -338,6 +338,10 @@ class SlideShow:
             time.sleep(0.01)
 
     def _create_label(self, file):
+        """Creates and returns a label from a file object that contains
+        valid valid json describing the text to use.
+        See: examples/sample_text_slide.json
+        """
         json_data = json.loads(file.read())
         _scale = 1
         if "scale" in json_data:

--- a/examples/images/sample_text_slide.json
+++ b/examples/images/sample_text_slide.json
@@ -2,7 +2,7 @@
   "text": "Sample Text\nSlideshow",
   "h_align": "CENTER",
   "v_align": "CENTER",
-  "color": "0x0000FF",
-  "background_color": "0xFF00FF",
+  "color": "0x000000",
+  "background_color": "0xFFFFFF",
   "scale": 2
 }

--- a/examples/images/sample_text_slide.json
+++ b/examples/images/sample_text_slide.json
@@ -2,7 +2,7 @@
   "text": "Sample Text\nSlideshow",
   "h_align": "CENTER",
   "v_align": "CENTER",
-  "color": "0x000000",
-  "background_color": "0xFFFFFF",
+  "color": "0xFFFFFF",
+  "background_color": "0x666666",
   "scale": 2
 }

--- a/examples/images/sample_text_slide.json
+++ b/examples/images/sample_text_slide.json
@@ -1,0 +1,7 @@
+{
+  "text": "Sample Text\nSlideshow",
+  "h_alignment": "CENTER",
+  "v_alignment": "CENTER",
+  "color": "0x0000FF",
+  "background_color": "0xFF00FF"
+}

--- a/examples/images/sample_text_slide.json
+++ b/examples/images/sample_text_slide.json
@@ -1,7 +1,8 @@
 {
   "text": "Sample Text\nSlideshow",
-  "h_alignment": "CENTER",
-  "v_alignment": "CENTER",
+  "h_align": "CENTER",
+  "v_align": "CENTER",
   "color": "0x0000FF",
-  "background_color": "0xFF00FF"
+  "background_color": "0xFF00FF",
+  "scale": 2
 }

--- a/examples/slideshow_alignment_test.py
+++ b/examples/slideshow_alignment_test.py
@@ -39,9 +39,9 @@ slideshow.h_align = aligns[i][1]
 slideshow.v_align = aligns[i][0]
 i += 1
 
-prev_img = slideshow.current_image_name
+prev_img = slideshow.current_slide_name
 while slideshow.update():
-    cur_img = slideshow.current_image_name
+    cur_img = slideshow.current_slide_name
     if prev_img != cur_img:
         slideshow.h_align = aligns[i][1]
         slideshow.v_align = aligns[i][0]

--- a/examples/slideshow_simpletest.py
+++ b/examples/slideshow_simpletest.py
@@ -1,14 +1,19 @@
+"""Basic demonstration script will create a slideshow
+object that plays through once alphabetically."""
 import board
-import pulseio
 from adafruit_slideshow import PlayBackOrder, SlideShow
+
+# use built in display (PyPortal, PyGamer, PyBadge, CLUE, etc.)
+# see guide for setting up external displays (TFT / OLED breakouts, RGB matrices, etc.)
+# https://learn.adafruit.com/circuitpython-display-support-using-displayio/display-and-display-bus
+display = board.DISPLAY
 
 # pylint: disable=no-member
 
-# Create the slideshow object that plays through once alphabetically.
 slideshow = SlideShow(
     board.DISPLAY,
-    pulseio.PWMOut(board.TFT_BACKLIGHT),
-    folder="/",
+    None,
+    folder="/images/",
     loop=False,
     order=PlayBackOrder.ALPHABETICAL,
 )

--- a/examples/slideshow_simpletest.py
+++ b/examples/slideshow_simpletest.py
@@ -16,6 +16,7 @@ slideshow = SlideShow(
     folder="/images/",
     loop=False,
     order=PlayBackOrder.ALPHABETICAL,
+    dwell=10,
 )
 
 while slideshow.update():


### PR DESCRIPTION
With these changes we can now use a file json file containing data like:
```json
{
  "text": "Sample Text\nSlideshow",
  "h_align": "CENTER",
  "v_align": "CENTER",
  "color": "0x0000FF",
  "background_color": "0xFF00FF",
  "scale": 2
}
```
It will create a label to show configured as specified by the json. `text` is the only required property. Any json files that do not contain `text` property are ignored. `h_align` and `v_align` properties from the json supersede the ones set on the SlideShow.

I have renamed many things that referred to "image" to now use "slide" instead since it can hold different types of things now. 

The sample json above is included in `examples/images/`