### PR TITLE
Use `os.path.join` to concatenate paths

### DIFF
--- a/adafruit_slideshow.py
+++ b/adafruit_slideshow.py
@@ -244,11 +244,11 @@ class SlideShow:
         # Load the image names before setting order so they can be reordered.
         self._img_start = None
         self._file_list = [
-            folder + f
+            os.path.join(folder, f)
             for f in os.listdir(folder)
             if (
                 not f.startswith(".")
-                and (f.endswith(".bmp") or _check_json_file(folder + f))
+                and (f.endswith(".bmp") or _check_json_file(os.path.join(folder, f)))
             )
         ]
 


### PR DESCRIPTION
While trying out the slideshow library for Adabox016, I noticed that the `folder` argument required  a trailing slash in order to work properly (from the example code: `folder="/images"` would fail, `folder="/images/"` would succeed).  Using `os.path.join(folder, f)` instead of `folder + f` fixes this issue.