### PR TITLE
Revert "Use `os.path.join` to concatenate paths"

### DIFF
--- a/adafruit_slideshow.py
+++ b/adafruit_slideshow.py
@@ -244,11 +244,11 @@ class SlideShow:
         # Load the image names before setting order so they can be reordered.
         self._img_start = None
         self._file_list = [
-            os.path.join(folder, f)
+            folder + f
             for f in os.listdir(folder)
             if (
                 not f.startswith(".")
-                and (f.endswith(".bmp") or _check_json_file(os.path.join(folder, f)))
+                and (f.endswith(".bmp") or _check_json_file(folder + f))
             )
         ]
 


### PR DESCRIPTION
Reverts adafruit/Adafruit_CircuitPython_Slideshow#30