### PR TITLE
Update the pixel_shader usage of OnDiskBitmap

### DIFF
--- a/adafruit_slideshow.py
+++ b/adafruit_slideshow.py
@@ -454,7 +454,10 @@ class SlideShow:
                 self._group.y = 0
 
             image_tilegrid = displayio.TileGrid(
-                odb, pixel_shader=displayio.ColorConverter()
+                odb,
+                pixel_shader=getattr(odb, "pixel_shader", displayio.ColorConverter()),
+                # TODO: Once CP6 is no longer supported, replace the above line with below
+                # pixel_shader=odb.pixel_shader,
             )
 
             self._group.append(image_tilegrid)


### PR DESCRIPTION
OnDiskBitmap has had incompatible changes in `7.0.0-alpha.3` - Ref: https://github.com/adafruit/circuitpython/pull/4823
This PR is part of a group of updates for this change - https://github.com/adafruit/circuitpython/issues/4982

This PR updates the library to the combined usage for CP6 & CP7 with a TODO to remove the CP6 compatibility in the future. It has been tested on a PyPortal with `6.3.0` and `7.0.0-alpha.4`